### PR TITLE
Wojciech Kosmalski - Etap 2, Mocki, zadanie nr 2

### DIFF
--- a/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/ExamConflicts.test.ts
+++ b/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/ExamConflicts.test.ts
@@ -1,0 +1,63 @@
+import { vi, it, expect, describe, beforeEach } from "vitest";
+import { ExamConflicts } from "./ExamConflicts";
+import { db } from "../utils/db";
+import { createExamRaw } from "./testHelpers";
+
+vi.mock("../utils/db");
+
+describe("constructor", () => {
+  it("should create instance of ExamConflicts", () => {
+    vi.setSystemTime("2025-07-01");
+    const instance = new ExamConflicts();
+    expect(instance).toBeInstanceOf(ExamConflicts);
+  });
+
+  it("should throw an error because exams can be managed only in July", () => {
+    vi.setSystemTime("2025-04-20");
+    expect(() => new ExamConflicts()).toThrowError(/managed/i);
+  });
+});
+
+describe("getExamById", () => {
+  let examConflicts: ExamConflicts;
+  const examId = 1;
+
+  beforeEach(() => {
+    vi.setSystemTime("2025-07-15");
+    examConflicts = new ExamConflicts();
+  });
+
+  it("should throw an error because exam was not found", async () => {
+    vi.mocked(db.sql).mockResolvedValue([]);
+    await expect(examConflicts.getExamById(examId)).rejects.toThrowError(
+      /not found/i
+    );
+  });
+
+  it("should return exam with given ID", async () => {
+    vi.mocked(db.sql).mockResolvedValue([createExamRaw({ id: examId })]);
+    const result = await examConflicts.getExamById(examId);
+
+    expect(result.id).toBe(examId);
+  });
+
+  it("should log warning when multiple exams found with same ID", async () => {
+    vi.mocked(db.sql).mockResolvedValue([
+      createExamRaw({ id: examId, subject: "First subject" }),
+      createExamRaw({ id: examId, subject: "Second subject" }),
+    ]);
+
+    const consoleSpy = vi.spyOn(console, "warn");
+    await examConflicts.getExamById(examId);
+
+    expect(consoleSpy).toBeCalledWith(
+      expect.stringMatching(/multiple exams found/i)
+    );
+  });
+
+  it("should propagate database errors", async () => {
+    const dbError = new Error("Database error");
+    vi.mocked(db.sql).mockRejectedValue(dbError);
+    await expect(examConflicts.getExamById(examId)).rejects.toThrow(dbError);
+  });
+});

--- a/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/ExamConflicts.ts
+++ b/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/ExamConflicts.ts
@@ -55,6 +55,15 @@ export class ExamConflicts {
       throw new Error(`Exam with ID ${id} not found`);
     }
 
+    if (result.length > 1) {
+      // Would it be better to throw an error?
+      console.warn(
+        `Multiple exams found with ID ${id}\nReturning exam: ${JSON.stringify(
+          result[0]
+        )}`
+      );
+    }
+
     const examRaw = result[0] as ExamRaw;
     return this.convertToExam(examRaw);
   }

--- a/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/testHelpers.ts
+++ b/1. Unit testing/2. Mocks/Task 02 - Exam conflicts/testHelpers.ts
@@ -1,0 +1,15 @@
+import { ExamRaw } from "./ExamConflicts";
+
+export function createExamRaw(overrides: Partial<ExamRaw> = {}) {
+  return {
+    id: 1,
+    subject: "Mathematics",
+    date: new Date().toISOString(),
+    durationMinutes: 90,
+    location: "Main Hall",
+    fee: 200,
+    earlyBirdDeadline: new Date("2025-06-13").toISOString(), // 7 days from now
+    registrationDeadline: new Date("2025-06-20").toISOString(), // 14 days from now,
+    ...overrides,
+  } as ExamRaw;
+}

--- a/1. Unit testing/vitest.config.ts
+++ b/1. Unit testing/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    clearMocks: true,
   },
 });


### PR DESCRIPTION
# Tested
- `constructor()`
- `getExamById()`

## Inne
- dodałem "czyszczenie" mocków przed każdym test case'm w konfigu vitesta
- dodałem logowanie w przypadku, gdy dwa (lub więcej) egzaminy mają to samo ID, ze względu na to, że nie jest to raczej pożądana sytuacja, więc chcemy wiedzieć o takich przypadkach
- helper do tworzenia obiektów `ExamRaw`